### PR TITLE
perf: Optimize bundles

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -94,7 +94,7 @@ module.exports = configure(function (ctx) {
 
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-framework
     framework: {
-      iconSet: 'svg-mdi-v5', // Quasar icon set
+      iconSet: 'mdi-v5', // Quasar icon set
       lang: 'en-US', // Quasar language pack
       config: {
         dark: 'auto'

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -11,22 +11,7 @@ const path = require('path')
 const ESLintPlugin = require('eslint-webpack-plugin')
 const { configure } = require('quasar/wrappers')
 
-const iconSets = [
-  { label: 'Material Icons (Google)', value: 'material-icons' },
-  { label: 'Material Icons Outlined (Google)', value: 'material-icons-outlined' },
-  { label: 'Material Icons Round (Google)', value: 'material-icons-round' },
-  { label: 'Material Icons Sharp (Google)', value: 'material-icons-sharp' },
-  { label: 'MDI v3 (Material Design Icons)', value: 'mdi-v3' },
-  { label: 'MDI v4 (Material Design Icons)', value: 'mdi-v4' },
-  { label: 'MDI v5 (Material Design Icons)', value: 'mdi-v5' },
-  { label: 'Fontawesome v5', value: 'fontawesome-v5' },
-  { label: 'Ionicons v4', value: 'ionicons-v4' },
-  { label: 'Ionicons v5', value: 'ionicons-v5' },
-  { label: 'Eva Icons', value: 'eva-icons' },
-  { label: 'Themify', value: 'themify' },
-  { label: 'Line Awesome', value: 'line-awesome' },
-  { label: 'Bootstrap Icons', value: 'bootstrap-icons' }
-]
+const { iconSets } = require('./src/icon-sets')
 
 module.exports = configure(function (ctx) {
   return {
@@ -96,7 +81,7 @@ module.exports = configure(function (ctx) {
       remove: [
         'quasar/dist/api',
 
-        ...iconSets.map(iconSet => `@quasar/extras/${ iconSet.value }`)
+        ...iconSets.flatMap(({ children }) => children).map(({ packageName, value }) => `${ packageName }/${ value }`)
       ]
     },
 

--- a/src/icon-sets.js
+++ b/src/icon-sets.js
@@ -1,0 +1,43 @@
+// IMPORTANT NOTE
+// We need to import this file both in app and quasar.conf.js.
+// Since quasar.conf.js runs on Node context and this file can't be transpiled before build, we need to make Node happy, and can't use ES modules and such.
+
+const iconSets = [
+  {
+    label: '@quasar/extras',
+    children: [
+      { label: 'Material Icons (Google)', value: 'material-icons', packageName: '@quasar/extras' },
+      { label: 'Material Icons Outlined (Google)', value: 'material-icons-outlined', packageName: '@quasar/extras' },
+      { label: 'Material Icons Round (Google)', value: 'material-icons-round', packageName: '@quasar/extras' },
+      { label: 'Material Icons Sharp (Google)', value: 'material-icons-sharp', packageName: '@quasar/extras' },
+      { label: 'MDI v5 (Material Design Icons)', value: 'mdi-v5', packageName: '@quasar/extras' },
+      { label: 'Fontawesome v5', value: 'fontawesome-v5', packageName: '@quasar/extras' },
+      { label: 'Ionicons v5', value: 'ionicons-v5', packageName: '@quasar/extras' },
+      { label: 'Eva Icons', value: 'eva-icons', packageName: '@quasar/extras' },
+      { label: 'Themify', value: 'themify', packageName: '@quasar/extras' },
+      { label: 'Line Awesome', value: 'line-awesome', packageName: '@quasar/extras' },
+      { label: 'Bootstrap Icons', value: 'bootstrap-icons', packageName: '@quasar/extras' }
+    ]
+  },
+  {
+    label: 'quasar-extras-svg-icons',
+    children: [
+      { label: 'Fluent Icons', value: 'fluentui-system-icons', packageName: 'quasar-extras-svg-icons' },
+      { label: 'Hero Icons (outline)', value: 'hero-icons-outline', packageName: 'quasar-extras-svg-icons' },
+      { label: 'Hero Icons (solid)', value: 'hero-icons-solid', packageName: 'quasar-extras-svg-icons' },
+      { label: 'Iconoir Icons', value: 'iconoir-icons', packageName: 'quasar-extras-svg-icons' },
+      { label: 'Jam Icons', value: 'jam-icons', packageName: 'quasar-extras-svg-icons' },
+      { label: 'Octicons', value: 'oct-icons', packageName: 'quasar-extras-svg-icons' },
+      { label: 'Pixelart Icons', value: 'pixelart-icons', packageName: 'quasar-extras-svg-icons' },
+      { label: 'Prime Icons', value: 'prime-icons', packageName: 'quasar-extras-svg-icons' },
+      { label: 'Remix Icons', value: 'remix-icons', packageName: 'quasar-extras-svg-icons' },
+      { label: 'Simple Icons', value: 'simple-icons', packageName: 'quasar-extras-svg-icons' },
+      { label: 'Tabler Icons', value: 'tabler-icons', packageName: 'quasar-extras-svg-icons' },
+      { label: 'Zond Icons', value: 'zond-icons', packageName: 'quasar-extras-svg-icons' }
+    ]
+  }
+];
+
+module.exports = {
+  iconSets
+}

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -168,6 +168,7 @@ export default defineComponent({
         import(
           /* webpackChunkName: "[request]" */
           /* webpackInclude: /index\.js$/ */
+          /* webpackExclude: /(mdi-v4|ionicons-v4)/ */
           '@quasar/extras/' + val.value
         ).then(async svgFile => {
           this.importedIcons = markRaw(svgFile)

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -93,6 +93,7 @@
 import { defineComponent, markRaw } from 'vue'
 import { copyToClipboard } from 'quasar'
 import { mdiCardSearchOutline, mdiChevronUp, mdiContentCopy } from '@quasar/extras/mdi-v5'
+import { iconSets } from 'src/icon-sets'
 
 export default defineComponent({
   name: 'SvgIconViewer',
@@ -102,36 +103,9 @@ export default defineComponent({
       mdiCardSearchOutline,
       mdiChevronUp,
       mdiContentCopy,
+
       icon: null,
-      iconSets: [
-        { label: '@quasar/extras', children: [
-          { label: 'Material Icons (Google)', value: 'material-icons', packageName: '@quasar/extras' },
-          { label: 'Material Icons Outlined (Google)', value: 'material-icons-outlined', packageName: '@quasar/extras' },
-          { label: 'Material Icons Round (Google)', value: 'material-icons-round', packageName: '@quasar/extras' },
-          { label: 'Material Icons Sharp (Google)', value: 'material-icons-sharp', packageName: '@quasar/extras' },
-          { label: 'MDI v5 (Material Design Icons)', value: 'mdi-v5', packageName: '@quasar/extras' },
-          { label: 'Fontawesome v5', value: 'fontawesome-v5', packageName: '@quasar/extras' },
-          { label: 'Ionicons v5', value: 'ionicons-v5', packageName: '@quasar/extras' },
-          { label: 'Eva Icons', value: 'eva-icons', packageName: '@quasar/extras' },
-          { label: 'Themify', value: 'themify', packageName: '@quasar/extras' },
-          { label: 'Line Awesome', value: 'line-awesome', packageName: '@quasar/extras' },
-          { label: 'Bootstrap Icons', value: 'bootstrap-icons', packageName: '@quasar/extras' }
-        ] },
-        { label: 'quasar-extras-svg-icons', children: [
-          { label: 'Fluent Icons', value: 'fluentui-system-icons', packageName: 'quasar-extras-svg-icons' },
-          { label: 'Hero Icons (outline)', value: 'hero-icons-outline', packageName: 'quasar-extras-svg-icons' },
-          { label: 'Hero Icons (solid)', value: 'hero-icons-solid', packageName: 'quasar-extras-svg-icons' },
-          { label: 'Iconoir Icons', value: 'iconoir-icons', packageName: 'quasar-extras-svg-icons' },
-          { label: 'Jam Icons', value: 'jam-icons', packageName: 'quasar-extras-svg-icons' },
-          { label: 'Octicons', value: 'oct-icons', packageName: 'quasar-extras-svg-icons' },
-          { label: 'Pixelart Icons', value: 'pixelart-icons', packageName: 'quasar-extras-svg-icons' },
-          { label: 'Prime Icons', value: 'prime-icons', packageName: 'quasar-extras-svg-icons' },
-          { label: 'Remix Icons', value: 'remix-icons', packageName: 'quasar-extras-svg-icons' },
-          { label: 'Simple Icons', value: 'simple-icons', packageName: 'quasar-extras-svg-icons' },
-          { label: 'Tabler Icons', value: 'tabler-icons', packageName: 'quasar-extras-svg-icons' },
-          { label: 'Zond Icons', value: 'zond-icons', packageName: 'quasar-extras-svg-icons' }
-        ] }
-      ],
+      iconSets,
       importedIcons: null,
       filter: '',
       dialogRef: null,

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -13,7 +13,7 @@
           </div>
 
           <q-btn-group push>
-            <q-btn push :icon="mdiContentCopy" @click="onCopyName(currentPath, currentName)">
+            <q-btn push icon="mdi-content-copy" @click="onCopyName(currentPath, currentName)">
               <q-tooltip>Copy name to clipboard</q-tooltip>
             </q-btn>
             <q-btn push label="SVG" @click="onCopySvg(currentPath, currentName)">
@@ -60,7 +60,7 @@
       <span>Totals: {{ filteredCount }}/{{ iconCount }}</span>
       <q-input borderless dense outlined debounce="300" clearable v-model="filter" placeholder="Search" style="margin: 2px;">
         <template v-slot:append>
-          <q-icon v-if="!filter" :name="mdiCardSearchOutline" />
+          <q-icon v-if="!filter" name="mdi-card-search-outline" />
         </template>
       </q-input>
     </div>
@@ -82,7 +82,7 @@
 
     <q-page-scroller expand position="bottom" :scroll-offset="150" :offset="[0, 0]">
       <div class="col cursor-pointer q-pa-sm text-center glass">
-        <q-icon :name="mdiChevronUp" size="lg" />
+        <q-icon name="mdi-chevron-up" size="lg" />
       </div>
     </q-page-scroller>
 
@@ -92,7 +92,6 @@
 <script>
 import { defineComponent, markRaw } from 'vue'
 import { copyToClipboard } from 'quasar'
-import { mdiCardSearchOutline, mdiChevronUp, mdiContentCopy } from '@quasar/extras/mdi-v5'
 import { iconSets } from 'src/icon-sets'
 
 export default defineComponent({
@@ -100,10 +99,6 @@ export default defineComponent({
 
   data () {
     return {
-      mdiCardSearchOutline,
-      mdiChevronUp,
-      mdiContentCopy,
-
       icon: null,
       iconSets,
       importedIcons: null,


### PR DESCRIPTION
Before:
```
 ╔═════════════════════════════════════╤═════════════╤════════════╗
 ║                               Asset │        Size │    Gzipped ║
 ╟─────────────────────────────────────┼─────────────┼────────────╢
 ║                    244.c81e3b0c.css │     0.04 KB │    0.06 KB ║
 ║                    app.36574589.css │   444.66 KB │   75.93 KB ║
 ╟─────────────────────────────────────┼─────────────┼────────────╢
 ║                     193.d489049a.js │     0.72 KB │    0.48 KB ║
 ║                     244.a0841e52.js │    12.98 KB │    3.82 KB ║
 ║                      94.4067cd85.js │     4.08 KB │    1.54 KB ║
 ║                     app.9f1bda42.js │  2113.89 KB │  635.34 KB ║
 ║         bootstrap-icons.ee78e323.js │   576.83 KB │  126.08 KB ║
 ║               eva-icons.70bd96f6.js │   155.84 KB │   43.08 KB ║
 ║          fontawesome-v5.4428db7a.js │  1133.51 KB │  414.60 KB ║
 ║             ionicons-v4.79007ff2.js │   371.88 KB │  137.06 KB ║
 ║             ionicons-v5.fca87454.js │   643.90 KB │  195.48 KB ║
 ║            line-awesome.9c073e54.js │  1916.79 KB │  545.96 KB ║
 ║ material-icons-outlined.f959cf19.js │   668.53 KB │  217.95 KB ║
 ║    material-icons-round.1ed8f0e0.js │   910.64 KB │  271.51 KB ║
 ║    material-icons-sharp.690c4046.js │   521.07 KB │  176.65 KB ║
 ║          material-icons.990f5df2.js │   591.61 KB │  193.50 KB ║
 ║                  mdi-v4.57a2f11f.js │  1672.53 KB │  521.72 KB ║
 ║                 themify.0098dfe5.js │   177.54 KB │   60.09 KB ║
 ║                  vendor.349028a6.js │ 10002.19 KB │ 2772.17 KB ║
 ╚═════════════════════════════════════╧═════════════╧════════════╝
 ```
 
After:
```
 ╔═════════════════════════════════════╤════════════╤════════════╗
 ║                               Asset │       Size │    Gzipped ║
 ╟─────────────────────────────────────┼────────────┼────────────╢
 ║                    650.c81e3b0c.css │    0.04 KB │    0.06 KB ║
 ║                    app.36574589.css │  444.66 KB │   75.93 KB ║
 ╟─────────────────────────────────────┼────────────┼────────────╢
 ║                     193.d489049a.js │    0.72 KB │    0.48 KB ║
 ║                     650.6a0e4249.js │   12.66 KB │    3.77 KB ║
 ║                      94.10226c3e.js │    4.08 KB │    1.54 KB ║
 ║                     app.e5adcd7b.js │    5.98 KB │    2.86 KB ║
 ║         bootstrap-icons.ee78e323.js │  576.83 KB │  126.08 KB ║
 ║               eva-icons.70bd96f6.js │  155.84 KB │   43.08 KB ║
 ║   fluentui-system-icons.d8d31c03.js │ 3871.54 KB │  892.62 KB ║
 ║          fontawesome-v5.4428db7a.js │ 1133.51 KB │  414.60 KB ║
 ║      hero-icons-outline.3ab2743b.js │   53.26 KB │   11.36 KB ║
 ║        hero-icons-solid.ad955dd4.js │   62.09 KB │   16.24 KB ║
 ║           iconoir-icons.2e8a26d4.js │  595.13 KB │   97.56 KB ║
 ║             ionicons-v5.fca87454.js │  643.90 KB │  195.48 KB ║
 ║               jam-icons.8e837efa.js │  393.12 KB │   97.87 KB ║
 ║            line-awesome.9c073e54.js │ 1916.79 KB │  545.96 KB ║
 ║ material-icons-outlined.f959cf19.js │  668.53 KB │  217.95 KB ║
 ║    material-icons-round.1ed8f0e0.js │  910.64 KB │  271.51 KB ║
 ║    material-icons-sharp.690c4046.js │  521.07 KB │  176.65 KB ║
 ║          material-icons.990f5df2.js │  591.61 KB │  193.50 KB ║
 ║                  mdi-v5.d96dda77.js │ 2108.40 KB │  632.53 KB ║
 ║               oct-icons.7216fa97.js │  214.70 KB │   63.41 KB ║
 ║          pixelart-icons.9b843a16.js │   67.02 KB │   17.89 KB ║
 ║             prime-icons.94d7801c.js │   81.83 KB │   21.41 KB ║
 ║             remix-icons.b4993176.js │  680.08 KB │  171.41 KB ║
 ║            simple-icons.af897825.js │ 2862.63 KB │ 1196.13 KB ║
 ║            tabler-icons.e51a47f1.js │  763.05 KB │   65.37 KB ║
 ║                 themify.0098dfe5.js │  177.54 KB │   60.09 KB ║
 ║                  vendor.576c3ab1.js │  309.58 KB │  105.10 KB ║
 ║              zond-icons.61d60c9a.js │   49.45 KB │   14.56 KB ║
 ╚═════════════════════════════════════╧════════════╧════════════╝
 ```